### PR TITLE
Add information about pod install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Don't forget to install dependencies:
 > cd reanimated-2-playground && yarn
 ```
 
+If you want to install app on the iOS simulator:
+```bash
+npx pod-install
+``
+
 Then run the app using Xcode or `react-native` CLI.
 
 [Check Reanimated 2 documentation here.](docs.swmansion.com/react-native-reanimated/)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Don't forget to install dependencies:
 If you want to install app on the iOS simulator:
 ```bash
 npx pod-install
-``
+```
 
 Then run the app using Xcode or `react-native` CLI.
 


### PR DESCRIPTION
If user uses commands:

```bash
git clone git@github.com:software-mansion-labs/reanimated-2-playground.git`
cd reanimated-2-playground
yarn run ios
```

Then he will face a cryptic error mentioning error code 65 which might be well known for some people but doesn't make it obvious that the reason is missing `pod install`.

```
info Found Xcode workspace "Reanimated2Playground.xcworkspace"
info Launching iPhone 11 (iOS 13.5)
info Building (using "xcodebuild -workspace Reanimated2Playground.xcworkspace -configuration Debug -scheme Reanimated2Playground -destination id=10C41B79-D386-4990-BCC2-8D8410C3710F")
.............
error Failed to build iOS project. We ran "xcodebuild" command but it exited with error code 65. To debug build logs further, consider building your app with Xcode.app, by opening Reanimated2Playground.xcworkspace. Run CLI with --verbose flag for more details.
Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -workspace Reanimated2Playground.xcworkspace -configuration Debug -scheme Reanimated2Playground -destination id=10C41B79-D386-4990-BCC2-8D8410C3710F
```

I suggest adding a small mention of the `pod install` to the README (what is also a common practice in other repos).