### PR TITLE
Fix syntax error on Podfile

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -17,7 +17,7 @@ target 'Reanimated2Playground' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!('Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1')
+  use_flipper!({'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1'})
   post_install do |installer|
     flipper_post_install(installer)
   end


### PR DESCRIPTION
There are missing curly brackets on the `use_flipper!` statement, which is causing a syntax error when running `npx pod-install`.

This PR fixes this by adding the missing curly brackets, allowing the installation to go through successfully.

More on https://fbflipper.com/docs/getting-started/react-native-ios/.